### PR TITLE
Fix workout history filtering and grouping

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,28 +129,23 @@
             return record ? record.duration : 0;
         }
         
-        function getWorkoutSessions(planName) {
+        function getWorkoutSessions(planId) {
             const sessions = state.workoutHistory
-                .filter(record => record.planName === planName)
+                .filter(record => record.planId === planId)
                 .reduce((acc, record) => {
                     const dateKey = new Date(record.date).toLocaleDateString();
-                    if (!acc[dateKey]) acc[dateKey] = [];
-                    acc[dateKey].push(record);
+                    if (!acc[dateKey]) {
+                        acc[dateKey] = { date: dateKey, records: [] };
+                    }
+                    acc[dateKey].records.push(record);
                     return acc;
                 }, {});
 
-            return Object.entries(sessions)
-                .sort(([a], [b]) => new Date(b) - new Date(a))
-                .map(([date, records]) => {
-                    const exercises = records.reduce((acc, record) => {
-                        if (!acc[record.exercise]) {
-                            acc[record.exercise] = { name: record.exercise, sets: [] };
-                        }
-                        acc[record.exercise].sets.push(record);
-                        acc[record.exercise].sets.sort((a, b) => a.set - b.set);
-                        return acc;
-                    }, {});
-                    return { date, exercises: Object.values(exercises) };
+            return Object.values(sessions)
+                .sort((a, b) => new Date(b.date) - new Date(a.date))
+                .map(session => {
+                    session.records.sort((a, b) => new Date(a.date) - new Date(b.date));
+                    return session;
                 });
         }
 
@@ -283,7 +278,7 @@
                 set: state.currentSetIndex + 1,
                 reps: state.currentReps,
                 weight: state.currentWeight,
-                planName: state.currentWorkout.name,
+                planId: state.currentWorkout.id,
                 type: 'reps'
             });
             saveData();
@@ -315,7 +310,7 @@
                 exercise: currentExercise.name,
                 set: state.currentSetIndex + 1,
                 duration: finalDuration,
-                planName: state.currentWorkout.name,
+                planId: state.currentWorkout.id,
                 type: 'time'
             });
             saveData();
@@ -543,8 +538,8 @@
         }
         
         function renderPlanHistory() {
-            const sessions = getWorkoutSessions(state.selectedPlan.name);
             const plan = state.selectedPlan;
+            const sessions = getWorkoutSessions(plan.id);
 
             return `
                 <div class="gradient-bg text-white p-6 flex items-center gap-3 sticky top-0 shadow-md">
@@ -595,17 +590,16 @@
                                         <div class="bg-gray-50 p-4 border-b">
                                             <h3 class="font-semibold text-gray-800">${session.date}</h3>
                                         </div>
-                                        <div class="p-4 space-y-4">
-                                            ${session.exercises.map(exercise => `
-                                                <div>
-                                                    <h4 class="font-medium text-gray-800 mb-2">${exercise.name}</h4>
-                                                    <div class="grid grid-cols-1 gap-2">
-                                                        ${exercise.sets.map(set => `
-                                                            <div class="flex justify-between items-center py-1 px-3 bg-gray-50 rounded text-sm">
-                                                                <span class="text-gray-600">Set ${set.set}</span>
-                                                                <span class="font-medium">${set.type === 'reps' ? `${set.reps} reps × ${set.weight} lbs` : `${set.duration}s`}</span>
-                                                            </div>
-                                                        `).join('')}
+                                        <div class="p-4 space-y-2">
+                                            ${session.records.map(record => `
+                                                <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                                                    <div>
+                                                        <p class="font-medium text-gray-800">${record.exercise}</p>
+                                                        <p class="text-sm text-gray-500">Set ${record.set}</p>
+                                                    </div>
+                                                    <div class="text-right">
+                                                        <p class="font-semibold text-gray-800">${record.type === 'reps' ? `${record.reps} reps` : `${record.duration}s`}</p>
+                                                        ${record.type === 'reps' ? `<p class="text-sm text-gray-500">${record.weight} lbs</p>` : ''}
                                                     </div>
                                                 </div>
                                             `).join('')}


### PR DESCRIPTION
- The workout history is now filtered by a unique plan ID instead of the plan name. This prevents workouts from different plans that share the same name from being displayed together.
- The workout history display has been updated to group all exercises within a single session chronologically, rather than grouping them by exercise type. This provides a clearer and more accurate log of the user's workout.